### PR TITLE
fix: IslamicI18n WEEKDAYS order:

### DIFF
--- a/projects/ngx-hijri-gregorian-datepicker/src/lib/hijri-gregorian-datepicker/IslamicI18n.ts
+++ b/projects/ngx-hijri-gregorian-datepicker/src/lib/hijri-gregorian-datepicker/IslamicI18n.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { NgbDatepickerI18n, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 
-const WEEKDAYS = ['أحد', 'إثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت'];
+const WEEKDAYS = ['إثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت', 'أحد'];
 const MONTHS = ['محرم', 'صفر', 'ربيع الأول', 'ربيع الآخر', 'جمادى الأولى', 'جمادى الآخرة', 'رجب', 'شعبان', 'رمضان', 'شوال',
   'ذو القعدة', 'ذو الحجة'];
 


### PR DESCRIPTION
The weekdays order didn't follow the one provided by Ngb-datepicker at: https://ng-bootstrap.github.io/#/components/datepicker/calendars#islamicumalqura

Fixing: https://github.com/EslamElmadny/HijriGregorianDatepicker/issues/14